### PR TITLE
Fix single allocation object response

### DIFF
--- a/src/Requests/GetAllocations.php
+++ b/src/Requests/GetAllocations.php
@@ -30,9 +30,15 @@ class GetAllocations extends Request implements Paginatable
     /** @return array<int, AllocationData> */
     public function createDtoFromResponse(Response $response): array
     {
+        $data = $response->json() ?? [];
+
+        if (! array_is_list($data)) {
+            $data = [$data];
+        }
+
         return array_map(
             fn (array $object) => AllocationData::createFromResponse($object),
-            $response->json()
+            $data
         );
     }
 }

--- a/src/Requests/GetAllocations.php
+++ b/src/Requests/GetAllocations.php
@@ -30,7 +30,7 @@ class GetAllocations extends Request implements Paginatable
     /** @return array<int, AllocationData> */
     public function createDtoFromResponse(Response $response): array
     {
-        $data = $response->json() ?? [];
+        $data = $response->json();
 
         if (! array_is_list($data)) {
             $data = [$data];

--- a/src/Requests/GetPublicHolidays.php
+++ b/src/Requests/GetPublicHolidays.php
@@ -3,10 +3,11 @@
 namespace Spatie\FloatSdk\Requests;
 
 use Saloon\Enums\Method;
+use Saloon\Http\Request;
 use Saloon\Http\Response;
 use Spatie\FloatSdk\Data\PublicHolidayData;
 
-class GetPublicHolidays extends \Saloon\Http\Request
+class GetPublicHolidays extends Request
 {
     protected Method $method = Method::GET;
 

--- a/tests/Requests/GetAllocationsTest.php
+++ b/tests/Requests/GetAllocationsTest.php
@@ -4,8 +4,8 @@ namespace Spatie\FloatSdk\Tests\Requests;
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
-use Spatie\FloatSdk\FloatClient;
 use Spatie\FloatSdk\Data\AllocationData;
+use Spatie\FloatSdk\FloatClient;
 use Spatie\FloatSdk\Requests\GetAllocation;
 use Spatie\FloatSdk\Requests\GetAllocations;
 

--- a/tests/Requests/GetAllocationsTest.php
+++ b/tests/Requests/GetAllocationsTest.php
@@ -5,6 +5,7 @@ namespace Spatie\FloatSdk\Tests\Requests;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Spatie\FloatSdk\FloatClient;
+use Spatie\FloatSdk\Data\AllocationData;
 use Spatie\FloatSdk\Requests\GetAllocation;
 use Spatie\FloatSdk\Requests\GetAllocations;
 
@@ -102,4 +103,24 @@ it('can fetch a single allocation via resource', function () {
     expect($response->json())
         ->toBeArray()
         ->toHaveKeys(['task_id', 'project_id', 'people_id']);
+});
+
+it('handles a single-object response from the Float API', function () {
+    // Float API sometimes returns a bare object instead of an array when there is only one result
+    $mockClient = new MockClient([
+        GetAllocations::class => MockResponse::make(body: $this->singleAllocation),
+    ]);
+
+    $response = $this->client
+        ->withMockClient($mockClient)
+        ->send(new GetAllocations);
+
+    $dtos = $response->dto();
+
+    expect($dtos)
+        ->toBeArray()
+        ->toHaveCount(1)
+        ->each->toBeInstanceOf(AllocationData::class);
+
+    expect($dtos[0]->taskId)->toBe(1);
 });

--- a/tests/Requests/GetClientsTest.php
+++ b/tests/Requests/GetClientsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\FloatSdk\Tests\Requests;
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\PaginationPlugin\Paginator;
 use Spatie\FloatSdk\FloatClient;
 use Spatie\FloatSdk\Requests\GetClient;
 use Spatie\FloatSdk\Requests\GetClients;
@@ -45,7 +46,7 @@ it('can fetch all clients via resource', function () {
         ->withMockClient($this->mockClient)
         ->clients()->all();
 
-    expect($paginator)->toBeInstanceOf(\Saloon\PaginationPlugin\Paginator::class);
+    expect($paginator)->toBeInstanceOf(Paginator::class);
 });
 
 it('can fetch a single client', function () {

--- a/tests/Requests/GetProjectsTest.php
+++ b/tests/Requests/GetProjectsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\FloatSdk\Tests\Requests;
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\PaginationPlugin\Paginator;
 use Spatie\FloatSdk\FloatClient;
 use Spatie\FloatSdk\Requests\GetProject;
 use Spatie\FloatSdk\Requests\GetProjects;
@@ -45,7 +46,7 @@ it('can fetch all projects via resource', function () {
         ->withMockClient($this->mockClient)
         ->projects()->all();
 
-    expect($paginator)->toBeInstanceOf(\Saloon\PaginationPlugin\Paginator::class);
+    expect($paginator)->toBeInstanceOf(Paginator::class);
 });
 
 it('can fetch a single project', function () {

--- a/tests/Requests/GetTimeOffTest.php
+++ b/tests/Requests/GetTimeOffTest.php
@@ -4,6 +4,7 @@ namespace Spatie\FloatSdk\Tests\Requests;
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\PaginationPlugin\Paginator;
 use Spatie\FloatSdk\FloatClient;
 use Spatie\FloatSdk\Requests\GetTimeoffs;
 use Spatie\FloatSdk\Requests\GetTimeOffTypes;
@@ -66,7 +67,7 @@ it('can fetch all timeoffs via resource', function () {
         ->withMockClient($this->mockClient)
         ->timeOff()->all('2025-01-01', '2025-12-31');
 
-    expect($paginator)->toBeInstanceOf(\Saloon\PaginationPlugin\Paginator::class);
+    expect($paginator)->toBeInstanceOf(Paginator::class);
 });
 
 it('can fetch timeoff types', function () {


### PR DESCRIPTION
Fix GetAllocations when Float API returns a single allocation object instead of an array